### PR TITLE
refactor(library): smooth card implementation

### DIFF
--- a/src/Dedge.Cardizer/Dedge.Cardizer.fs
+++ b/src/Dedge.Cardizer/Dedge.Cardizer.fs
@@ -116,13 +116,9 @@ type Cardizer =
     static member NextVisa([<Optional; DefaultParameterValue(VisaLengthOptions.Random)>] visaLengthOption) =
         let length =
             match visaLengthOption with
-            | VisaLengthOptions.Thirteen -> 13
-            | VisaLengthOptions.Sixteen -> 16
-            | _ ->
-                if Cardizer.next 2 = 0 then
-                    13
-                else
-                    16
+            | VisaLengthOptions.Random -> if Cardizer.next 2 = 0 then 13 else 16
+            | _ -> int visaLengthOption
+                
 
         Cardizer.GenerateCard [ 4 ] length
 
@@ -229,12 +225,7 @@ type Cardizer =
     /// </code>
     /// </example>
     static member NextAmex() =
-        let second =
-            if Cardizer.next 2 = 0 then
-                4
-            else
-                7
-
+        let second = if Cardizer.next 2 = 0 then 4 else 7
         Cardizer.GenerateCard [3; second] 15
 
     /// <summary>Returns a random Discover number that is of the given available length.</summary>


### PR DESCRIPTION
Hello,

We may loose some minor performance but the API is far friendlier now. Beside we don't care that much about perf. This is a library for testing after all.

Let's take MIR for example, now we can write 

```fs
    static member NextMir([<Optional; DefaultParameterValue(MirLengthOptions.Random)>] mirLengthOption) =
        let length =
            match mirLengthOption with
            | MirLengthOptions.Random -> Cardizer.NextInRange 16 19
            | _ -> int mirLengthOption

        let prefixes = [ 2; 2; 0; Cardizer.next 5 ]

        Cardizer.GenerateCard prefixes length
```

instead of

```fs
   static member NextMir([<Optional; DefaultParameterValue(MirLengthOptions.Random)>] mirLengthOption) =
        let length =
            match mirLengthOption with
            | MirLengthOptions.Random -> Cardizer.nextInRange 16 19
            | _ -> int mirLengthOption

        let shift = (length + 1) % 2
        let prefixes = [ 2; 2; 0; Cardizer.next 5 ]

        let prefixes, state =
            [ 2; 2; 0; Cardizer.next 5 ]
            |> Cardizer.sumFold shift 0

        Cardizer.generateCard prefixes state length
```