### PR TITLE
ci: strip html and include readme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ jobs:
         run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test -c Release
+      - name: Strip HTML from README
+        uses: d-edge/strip-markdown-html@v0.1
+        with:
+          input-path: README.md
+          output-path: src/Dedge.Cardizer/README.md
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
         run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/src/Dedge.Cardizer/Dedge.Cardizer.fsproj
+++ b/src/Dedge.Cardizer/Dedge.Cardizer.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-     <!-- General -->
+    <!-- General -->
     <AssemblyName>Dedge.Cardizer</AssemblyName>
     <Description>A functional minimalist credit card randomizer to test application.</Description>
     <Copyright>Copyright 2021 D-EDGE</Copyright>
@@ -34,6 +34,8 @@
 
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <NoWarn>FS2003;FS0044</NoWarn>
+
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,6 +44,8 @@
       <Pack>true</Pack>
       <PackagePath>$(PackageIconUrl)</PackagePath>
     </None>
+
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Strip html from Readme
- Include readme into nuget

The goal is to fill a bit this blank space:

![image](https://user-images.githubusercontent.com/3449303/149370699-9d84a00b-0ef9-4c12-b7cc-b186982829ee.png)
