### PR TITLE
fix(ci): update pre-release version tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             echo Clean Version: $version
           else
             git fetch --prune --unshallow --tags --quiet
-            latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
+            latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
             runId=$GITHUB_RUN_ID
             version="${latestTag//v}-build.${runId}"
             echo Non-release version: $version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           else
             latestTag=$(git describe --tags --abbrev=0)
             echo latest tag: $latestTag
-            VERSION="${latestTag}-beta${GITHUB_RUN_ID}"
+            VERSION="${latestTag}-beta$GITHUB_RUN_ID"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,7 @@ jobs:
           else
             git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
-            noVTag="${latestTag//v}"
-            runId=$GITHUB_RUN_ID
-            version="${noVTag}-build${runId}"
+            version="${latestTag//v}-build.${$GITHUB_RUN_ID}"
             echo Non-release version: $version
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$version src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,6 @@ jobs:
             noVTag="${latestTag//v}"
             countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
             longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
-            echo long tag: $longTag
             runId=$GITHUB_RUN_ID
             VERSION="${longTag}-beta${runId}"
             echo Non-release version: $VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,21 +48,19 @@ jobs:
         run: |
           if [ "$GITHUB_REF_TYPE" = "tag" ]; then
             arrTag=(${GITHUB_REF//\// })
-            VERSION="${arrTag[2]}"
-            echo Version: $VERSION
-            VERSION="${VERSION//v}"
-            echo Clean Version: $VERSION
+            version="${arrTag[2]}"
+            echo Version: $version
+            version="${version//v}"
+            echo Clean Version: $version
           else
             git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
-            # noVTag="${latestTag//v}"
-            # countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
-            # longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
+            noVTag="${latestTag//v}"
             runId=$GITHUB_RUN_ID
-            VERSION="${latestTag}-build${runId}"
-            echo Non-release version: $VERSION
+            version="${noVTag}-build${runId}"
+            echo Non-release version: $version
           fi
-          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj
+          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$version src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
           else
             git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
-            noVTag="${latestTag//v}"
+            # noVTag="${latestTag//v}"
             # countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
             # longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
             runId=$GITHUB_RUN_ID
-            VERSION="${noVTag}-build${runId}"
+            VERSION="${latestTag}-build${runId}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,12 @@ jobs:
           else
             git fetch --prune --unshallow --tags
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
-            echo latest tag: $latestTag
+            noVTag="${latestTag//v}"
+            countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
+            longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
+            echo long tag: $longTag
             runId=$GITHUB_RUN_ID
-            VERSION="${latestTag}-beta${runId}"
+            VERSION="${longTag}-beta${runId}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,9 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            VERSION=$GITHUB_RUN_ID
+            git describe --tags --abbrev=0 >> $LATEST_TAG
+            echo latest tag: $LATEST_TAG
+            VERSION=${{ format('{0}-beta{1}', $LATEST_TAG, $GITHUB_RUN_ID) }}
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             echo Clean Version: $VERSION
           else
             readlink -f $(which sh)           
-            latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo v0.1.0; fi)
+            latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
             echo latest tag: $latestTag
             runId=$GITHUB_RUN_ID
             VERSION="${latestTag}-beta${runId}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
           else
             git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
-            version="${latestTag//v}-build.${$GITHUB_RUN_ID}"
+            runId=$GITHUB_RUN_ID
+            version="${latestTag//v}-build.${runId}"
             echo Non-release version: $version
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$version src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,10 @@ jobs:
             git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
             noVTag="${latestTag//v}"
-            countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
-            longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
+            # countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)
+            # longTag=$(case $countDot in "0") echo "$noVTag.0.0" ;; "1") echo "$noVTag.0" ;; *) echo "$noVTag";; esac;)
             runId=$GITHUB_RUN_ID
-            VERSION="${longTag}-beta${runId}"
+            VERSION="${noVTag}-build${runId}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-            echo "latest tag: ${{ env.LATEST_TAG }}"
-            echo '${{ env.Latest_TAG }}-beta${{ env.GITHUB_RUN_ID }}' >> $VERSION
+            latestTag=$(git describe --tags --abbrev=0)
+            echo latest tag: $latestTag
+            VERSION="${latestTag}-beta${GITHUB_RUN_ID}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           else
             echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
             echo "latest tag: ${{ env.LATEST_TAG }}"
-            echo '${{ env.Latest_TAG }}-beta${{ env.GITHUB_RUN_ID }} >> $VERSION
+            echo '${{ env.Latest_TAG }}-beta${{ env.GITHUB_RUN_ID }}' >> $VERSION
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,8 @@ jobs:
             echo Clean Version: $VERSION
           else
             echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-            echo "${{ env.LATEST_TAG }}"
-            VERSION=${{ format('{0}-beta{1}', env.LATEST_TAG, env.GITHUB_RUN_ID) }}
+            echo "latest tag: ${{ env.LATEST_TAG }}"
+            echo '${{ env.Latest_TAG }}-beta${{ env.GITHUB_RUN_ID }} >> $VERSION
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           else
             echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
             echo "${{ env.LATEST_TAG }}"
-            VERSION=${{ format('{0}-beta{1}', env.LATEST_TAG, $GITHUB_RUN_ID) }}
+            VERSION=${{ format('{0}-beta{1}', env.LATEST_TAG, env.GITHUB_RUN_ID) }}
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            git describe --tags --abbrev=0 >> $LATEST_TAG
-            echo latest tag: $LATEST_TAG
-            VERSION=${{ format('{0}-beta{1}', $LATEST_TAG, $GITHUB_RUN_ID) }}
+            echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+            echo "${{ env.LATEST_TAG }}"
+            VERSION=${{ format('{0}-beta{1}', env.LATEST_TAG, $GITHUB_RUN_ID) }}
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           else
             latestTag=$(git describe --tags --abbrev=0)
             echo latest tag: $latestTag
-            VERSION="${latestTag}-beta$GITHUB_RUN_ID"
+            VERSION="${latestTag}-beta${$GITHUB_RUN_ID}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             echo Clean Version: $VERSION
           else
             readlink -f $(which sh)           
-            latestTag=if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo v0.1.0; fi)
+            latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo v0.1.0; fi)
             echo latest tag: $latestTag
             runId=$GITHUB_RUN_ID
             VERSION="${latestTag}-beta${runId}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            readlink -f $(which sh)           
+            git fetch --prune --unshallow --tags
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
             echo latest tag: $latestTag
             runId=$GITHUB_RUN_ID

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            git fetch --prune --unshallow --tags
+            git fetch --prune --unshallow --tags --quiet
             latestTag=$(if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo 0.0.1; fi)
             noVTag="${latestTag//v}"
             countDot=$(echo -n $latestTag | sed -e 's/\(.\)/\1\n/g' | grep "\." | wc -l)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,11 @@ jobs:
             VERSION="${VERSION//v}"
             echo Clean Version: $VERSION
           else
-            latestTag=$(git describe --tags --abbrev=0)
+            readlink -f $(which sh)           
+            latestTag=if [ "$(git tag -l | wc -l)" -gt 0 ]; then git describe --tags --abbrev=0; else echo v0.1.0; fi)
             echo latest tag: $latestTag
-            VERSION="${latestTag}-beta${$GITHUB_RUN_ID}"
+            runId=$GITHUB_RUN_ID
+            VERSION="${latestTag}-beta${runId}"
             echo Non-release version: $VERSION
           fi
           dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj

--- a/src/DEdge.Cardizer/DEdge.Cardizer.fsproj
+++ b/src/DEdge.Cardizer/DEdge.Cardizer.fsproj
@@ -45,7 +45,7 @@
       <PackagePath>$(PackageIconUrl)</PackagePath>
     </None>
 
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="../../README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DEdge.Cardizer/DEdge.Cardizer.fsproj
+++ b/src/DEdge.Cardizer/DEdge.Cardizer.fsproj
@@ -45,7 +45,7 @@
       <PackagePath>$(PackageIconUrl)</PackagePath>
     </None>
 
-    <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello,

We had an overflow issue. NuGet doesn't like version 0.0.2239725856. This PR updates it to have either 0.0.1-build.2239725856 if no tag exists or {lastTag}-build.2239725856 if a tag is found.

Related to #123 